### PR TITLE
Use Travis to build and publish to GitHub Pages and Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,66 @@
+services:
+- docker
+
+env:
+  # Use this to set your game's name. It is being used
+  # throughout this file for naming exported artifacts.
+  # This will, for example, create an "Awesome Game.exe"
+  - GAME_NAME="TrueTurnTurnTurn"
+
+install:
+- docker pull gamedrivendesign/godot-export
+
+# Each of the following lines exports the game for a given platform.
+# You can specify the platform in the EXPORT_NAME variable
+# The exported game will be written to the folder specified after the second "-v" flag
+# "-v $(pwd)/output/html5:/build/output" writes the exported game to  the "output/html5" folder.
+script:
+- cd TrueTurnTurnTurn
+- docker run -e EXPORT_NAME="HTML5"           -e OUTPUT_FILENAME="index.html"           -v $(pwd):/build/src -v $(pwd)/output/html5:/build/output   gamedrivendesign/godot-export
+- docker run -e EXPORT_NAME="Linux/X11"       -e OUTPUT_FILENAME="${GAME_NAME}"         -v $(pwd):/build/src -v $(pwd)/output/linux:/build/output   gamedrivendesign/godot-export
+- docker run -e EXPORT_NAME="Windows Desktop" -e OUTPUT_FILENAME="${GAME_NAME}.exe"     -v $(pwd):/build/src -v $(pwd)/output/windows:/build/output gamedrivendesign/godot-export
+- docker run -e EXPORT_NAME="Mac OSX"         -e OUTPUT_FILENAME="${GAME_NAME}-mac.zip" -v $(pwd):/build/src -v $(pwd)/output/mac:/build/output     gamedrivendesign/godot-export
+
+# Now comes deployment related code.
+# To make this work, you need to set a GITHUB_TOKEN environment variable through
+# the TravisCI web ui. For more information take a look at the TravisCI docs:
+# https://docs.travis-ci.com/user/deployment/pages/#Setting-the-GitHub-token
+
+# This creates zip files from the exported game builds for the
+# three desktop platforms
+before_deploy:
+- zip -j "${GAME_NAME}-linux.zip"   output/linux/*
+- zip -j "${GAME_NAME}-windows.zip" output/windows/*
+# No need to zip the mac game, because it already is a zip
+- cp -R output/mac/* .
+
+deploy:
+# The following block is responsible to upload the zip files
+# created above to GitHub Releases whenever a new git tag
+# is created.
+- provider: releases
+  skip-cleanup: true
+  api_key: $GITHUB_TOKEN
+  file:
+    - "${GAME_NAME}-linux.zip"
+    - "${GAME_NAME}-windows.zip"
+    - "${GAME_NAME}-mac.zip"
+  on:
+    # Create GitHub Releases for new git tags
+    # regardless of the branch.
+    all_branches: true
+    tags: true
+
+# The following block is responsible for pushing the HTML5 version of the game
+# to GitHub Pages. To do so, Travis will commit the contents specified in "local-dir"
+# to a "gh-pages" branch in your repository. It will then be accessible at:
+# username.github.io/reponame if your repo is at github.com/username/reponame.
+- provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  local-dir: output/html5
+  on:
+    # This will only update the game with new commits from the master branch
+    # You can optionally only update the game on new git tags.
+    branch: master
+    # tags: true

--- a/TrueTurnTurnTurn/export_presets.cfg
+++ b/TrueTurnTurnTurn/export_presets.cfg
@@ -1,0 +1,97 @@
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+patch_list=PoolStringArray(  )
+
+[preset.0.options]
+
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+binary_format/64_bits=true
+custom_template/release=""
+custom_template/debug=""
+application/icon=""
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+
+[preset.1]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+patch_list=PoolStringArray(  )
+
+[preset.1.options]
+
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+binary_format/64_bits=true
+custom_template/release=""
+custom_template/debug=""
+
+[preset.2]
+
+name="Mac OSX"
+platform="Mac OSX"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+patch_list=PoolStringArray(  )
+
+[preset.2.options]
+
+custom_package/debug=""
+custom_package/release=""
+application/name=""
+application/info="Made with Godot Engine"
+application/icon=""
+application/identifier="org.godotengine.macgame"
+application/signature="godotmacgame"
+application/short_version="1.0"
+application/version="1.0"
+application/copyright=""
+application/bits_mode=0
+display/high_res=false
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+
+[preset.3]
+
+name="HTML5"
+platform="HTML5"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+patch_list=PoolStringArray(  )
+
+[preset.3.options]
+
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=true
+html/custom_html_shell=""
+html/head_include=""
+custom_template/release=""
+custom_template/debug=""


### PR DESCRIPTION
You can use Travis to automagically build and export your game. Travis is configured through the `.travis.yml` file to publish your game to GitHub Pages whenever you push, so you can always play the latest version in your browser (make sure to disable ad-blockers / enable JavaScript for it to work). Additionally, Travis is configured to push Windows, Linux and Mac versions of your game to GitHub Releases whenever you create a new tag.

To enable the Travis integration, the repository owner @BraunTom needs to head over to https://travis-ci.org and enable this repository after the PR was merged. Additionally, you need to set the `GITHUB_TOKEN` environment variable at Travis to a Personal Access Token with the `repo` scope, which you can generate here: https://github.com/settings/tokens. This is how it should look like on Travis:

![grafik](https://user-images.githubusercontent.com/2145092/39660767-bcdd2f2a-5045-11e8-8d7c-5cf8e16b846d.png)


Let me know if you have any feedback or further questions! 🎉 